### PR TITLE
Fix race errors with memory tables

### DIFF
--- a/memory/database.go
+++ b/memory/database.go
@@ -107,11 +107,11 @@ func (d *BaseDatabase) Name() string {
 
 // Tables returns all tables in the database.
 func (d *BaseDatabase) Tables() map[string]sql.Table {
-	d.tablesMu.Lock()
-	defer d.tablesMu.Unlock()
+	d.tablesMu.RLock()
+	defer d.tablesMu.RUnlock()
 	tables := make(map[string]sql.Table, len(d.tables))
 	for name, table := range d.tables {
-		d.tables[name] = table
+		tables[name] = table
 	}
 	return tables
 }

--- a/memory/database.go
+++ b/memory/database.go
@@ -107,9 +107,11 @@ func (d *BaseDatabase) Name() string {
 
 // Tables returns all tables in the database.
 func (d *BaseDatabase) Tables() map[string]sql.Table {
+	d.tablesMu.Lock()
+	defer d.tablesMu.Unlock()
 	tables := make(map[string]sql.Table, len(d.tables))
 	for name, table := range d.tables {
-		d.AddTable(name, table)
+		d.tables[name] = table
 	}
 	return tables
 }
@@ -140,8 +142,8 @@ func (d *BaseDatabase) putTable(t *Table) {
 	d.tablesMu.RLock()
 	for name, table := range d.tables {
 		if strings.ToLower(name) == lowerName {
-			d.tablesMu.RUnlock()
 			t.name = table.Name()
+			d.tablesMu.RUnlock()
 			d.AddTable(name, t)
 			return
 		}

--- a/memory/database.go
+++ b/memory/database.go
@@ -234,6 +234,8 @@ func (db *HistoryDatabase) AddTableAsOf(name string, t sql.Table, asOf interface
 
 // AddTable adds a new table to the database.
 func (d *BaseDatabase) AddTable(name string, t MemTable) {
+	d.tablesMu.Lock()
+	defer d.tablesMu.Unlock()
 	d.tables[name] = t
 }
 

--- a/memory/database.go
+++ b/memory/database.go
@@ -35,6 +35,7 @@ type Database struct {
 type MemoryDatabase interface {
 	sql.Database
 	AddTable(name string, t MemTable)
+	DeleteTable(name string)
 	Database() *BaseDatabase
 }
 
@@ -234,6 +235,11 @@ func (db *HistoryDatabase) AddTableAsOf(name string, t sql.Table, asOf interface
 // AddTable adds a new table to the database.
 func (d *BaseDatabase) AddTable(name string, t MemTable) {
 	d.tables[name] = t
+}
+
+// DeleteTable deletes a table from the database.
+func (d *BaseDatabase) DeleteTable(name string) {
+	delete(d.tables, name)
 }
 
 // CreateTable creates a table with the given name and schema

--- a/memory/database.go
+++ b/memory/database.go
@@ -241,6 +241,8 @@ func (d *BaseDatabase) AddTable(name string, t MemTable) {
 
 // DeleteTable deletes a table from the database.
 func (d *BaseDatabase) DeleteTable(name string) {
+	d.tablesMu.Lock()
+	defer d.tablesMu.Unlock()
 	delete(d.tables, name)
 }
 

--- a/memory/database.go
+++ b/memory/database.go
@@ -229,7 +229,7 @@ func (db *HistoryDatabase) AddTableAsOf(name string, t sql.Table, asOf interface
 	}
 
 	db.Revisions[strings.ToLower(name)][asOf] = t
-	db.tables[name] = t.(MemTable)
+	db.AddTable(name, t.(MemTable))
 }
 
 // AddTable adds a new table to the database.
@@ -248,7 +248,9 @@ func (d *BaseDatabase) DeleteTable(name string) {
 
 // CreateTable creates a table with the given name and schema
 func (d *BaseDatabase) CreateTable(ctx *sql.Context, name string, schema sql.PrimaryKeySchema, collation sql.CollationID, comment string) error {
+	d.tablesMu.RLock()
 	_, ok := d.tables[name]
+	d.tablesMu.RUnlock()
 	if ok {
 		return sql.ErrTableAlreadyExists.New(name)
 	}

--- a/memory/database.go
+++ b/memory/database.go
@@ -137,13 +137,16 @@ func (d *BaseDatabase) GetTableInsensitive(ctx *sql.Context, tblName string) (sq
 // putTable writes the table given into database storage. A table with this name must already be present.
 func (d *BaseDatabase) putTable(t *Table) {
 	lowerName := strings.ToLower(t.name)
+	d.tablesMu.RLock()
 	for name, table := range d.tables {
 		if strings.ToLower(name) == lowerName {
+			d.tablesMu.RUnlock()
 			t.name = table.Name()
 			d.AddTable(name, t)
 			return
 		}
 	}
+	d.tablesMu.RUnlock()
 	panic(fmt.Sprintf("table %s not found", t.name))
 }
 

--- a/memory/database.go
+++ b/memory/database.go
@@ -302,7 +302,7 @@ func (d *BaseDatabase) DropTable(ctx *sql.Context, name string) error {
 
 	SessionFromContext(ctx).dropTable(t.(*Table).data)
 
-	delete(d.tables, name)
+	d.DeleteTable(name)
 	return nil
 }
 
@@ -338,8 +338,8 @@ func (d *BaseDatabase) RenameTable(ctx *sql.Context, oldName, newName string) er
 	}
 	memTbl.data.tableName = newName
 
-	d.tables[newName] = memTbl
-	delete(d.tables, oldName)
+	d.AddTable(newName, memTbl)
+	d.DeleteTable(oldName)
 	sess.putTable(memTbl.data)
 
 	return nil

--- a/memory/database.go
+++ b/memory/database.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/fulltext"
 	"github.com/dolthub/go-mysql-server/sql/types"
+	"sync"
 )
 
 // Database is an in-memory database.
@@ -60,6 +61,7 @@ type BaseDatabase struct {
 	events            []sql.EventDefinition
 	primaryKeyIndexes bool
 	collation         sql.CollationID
+	tablesMu          *sync.RWMutex
 }
 
 var _ MemoryDatabase = (*Database)(nil)
@@ -76,9 +78,10 @@ func NewDatabase(name string) *Database {
 // NewViewlessDatabase creates a new database that doesn't persist views. Used only for testing. Use NewDatabase.
 func NewViewlessDatabase(name string) *BaseDatabase {
 	return &BaseDatabase{
-		name:   name,
-		tables: map[string]MemTable{},
-		fkColl: newForeignKeyCollection(),
+		name:     name,
+		tables:   map[string]MemTable{},
+		fkColl:   newForeignKeyCollection(),
+		tablesMu: &sync.RWMutex{},
 	}
 }
 

--- a/memory/database.go
+++ b/memory/database.go
@@ -140,7 +140,7 @@ func (d *BaseDatabase) putTable(t *Table) {
 	for name, table := range d.tables {
 		if strings.ToLower(name) == lowerName {
 			t.name = table.Name()
-			d.tables[name] = t
+			d.AddTable(name, t)
 			return
 		}
 	}
@@ -258,7 +258,7 @@ func (d *BaseDatabase) CreateTable(ctx *sql.Context, name string, schema sql.Pri
 		table.EnablePrimaryKeyIndexes()
 	}
 
-	d.tables[name] = table
+	d.AddTable(name, table)
 	sess := SessionFromContext(ctx)
 	sess.putTable(table.data)
 
@@ -289,7 +289,7 @@ func (d *BaseDatabase) CreateIndexedTable(ctx *sql.Context, name string, sch sql
 		}
 	}
 
-	d.tables[name] = table
+	d.AddTable(name, table)
 	return nil
 }
 


### PR DESCRIPTION
There are some data race errors with the memory table.

This wraps all methods in a mutex to ensure we don't have concurrency issues.